### PR TITLE
download_manager: optimize data structure to speed up lookup

### DIFF
--- a/include/torrent/download/download_manager.h
+++ b/include/torrent/download/download_manager.h
@@ -4,8 +4,11 @@
 #ifndef LIBTORRENT_DOWNLOAD_MANAGER_H
 #define LIBTORRENT_DOWNLOAD_MANAGER_H
 
-#include <torrent/common.h>
+#include <unordered_map>
 #include <vector>
+
+#include <torrent/common.h>
+#include <torrent/hash_string.h>
 
 namespace torrent {
 
@@ -58,6 +61,10 @@ public:
   iterator erase(DownloadWrapper* d) LIBTORRENT_NO_EXPORT;
 
   void clear() LIBTORRENT_NO_EXPORT;
+
+private:
+  std::unordered_map<HashString, size_type>  lookup_cache;
+  std::unordered_map<HashString, HashString> obfuscated_to_hash;
 };
 
 } // namespace torrent

--- a/include/torrent/hash_string.h
+++ b/include/torrent/hash_string.h
@@ -28,6 +28,10 @@ public:
 
   static constexpr size_type size_data = 20;
 
+  static constexpr unsigned int hashstring_hash_ofs = 8;
+  static_assert((hashstring_hash_ofs + sizeof(size_t)) <=
+                HashString::size_data);
+
   HashString() = default;
   HashString(const value_type* src) {
     assign(src);
@@ -35,6 +39,14 @@ public:
 
   size_type size() const {
     return size_data;
+  }
+
+  size_t hash() const {
+    size_t result = 0;
+    std::memcpy(&result,
+                m_data + torrent::HashString::hashstring_hash_ofs,
+                sizeof(size_t));
+    return result;
   }
 
   iterator begin() {
@@ -155,5 +167,31 @@ operator<=(const HashString& one, const HashString& two) {
 }
 
 } // namespace torrent
+
+namespace std {
+
+template<>
+struct hash<torrent::HashString> {
+  std::size_t operator()(const torrent::HashString& n) const noexcept {
+    return n.hash();
+  }
+};
+
+template<>
+struct hash<torrent::HashString*> {
+  std::size_t operator()(const torrent::HashString* n) const noexcept {
+    return n->hash();
+  }
+};
+
+template<>
+struct equal_to<torrent::HashString*> {
+  bool operator()(const torrent::HashString* a,
+                  const torrent::HashString* b) const noexcept {
+    return *a == *b;
+  }
+};
+
+}
 
 #endif

--- a/src/torrent/download/download_manager.cc
+++ b/src/torrent/download/download_manager.cc
@@ -37,9 +37,7 @@ DownloadManager::clear() {
 
 DownloadManager::iterator
 DownloadManager::find(const std::string& hash) {
-  return std::find_if(begin(), end(), [hash](DownloadWrapper* wrapper) {
-    return *HashString::cast_from(hash) == wrapper->info()->hash();
-  });
+  return find(*HashString::cast_from(hash));
 }
 
 DownloadManager::iterator

--- a/src/torrent/download/download_manager.cc
+++ b/src/torrent/download/download_manager.cc
@@ -13,15 +13,22 @@ DownloadManager::insert(DownloadWrapper* d) {
   if (find(d->info()->hash()) != end())
     throw internal_error("Could not add torrent as it already exists.");
 
+  lookup_cache.emplace(d->info()->hash(), size());
+  obfuscated_to_hash.emplace(d->info()->hash_obfuscated(), d->info()->hash());
+
   return base_type::insert(end(), d);
 }
 
 DownloadManager::iterator
 DownloadManager::erase(DownloadWrapper* d) {
-  iterator itr = std::find(begin(), end(), d);
+  auto itr = find(d->info()->hash());
 
   if (itr == end())
     throw internal_error("Tried to remove a torrent that doesn't exist");
+
+  lookup_cache.erase(lookup_cache.find(d->info()->hash()));
+  obfuscated_to_hash.erase(
+    obfuscated_to_hash.find(d->info()->hash_obfuscated()));
 
   delete *itr;
   return base_type::erase(itr);
@@ -29,10 +36,9 @@ DownloadManager::erase(DownloadWrapper* d) {
 
 void
 DownloadManager::clear() {
-  while (!empty()) {
-    delete base_type::back();
-    base_type::pop_back();
-  }
+  base_type::clear();
+  lookup_cache.clear();
+  obfuscated_to_hash.clear();
 }
 
 DownloadManager::iterator
@@ -42,33 +48,52 @@ DownloadManager::find(const std::string& hash) {
 
 DownloadManager::iterator
 DownloadManager::find(const HashString& hash) {
-  return std::find_if(begin(), end(), [hash](DownloadWrapper* wrapper) {
-    return hash == wrapper->info()->hash();
-  });
+  auto cached = lookup_cache.find(hash);
+
+  if (cached == lookup_cache.end()) {
+    return end();
+  }
+
+  auto cached_i = cached->second;
+
+  auto itr = cached_i < size() ? begin() + cached_i : end();
+  if (itr == end() || (*itr)->info()->hash() != hash) {
+    itr = std::find_if(begin(), end(), [hash](DownloadWrapper* wrapper) {
+      return hash == wrapper->info()->hash();
+    });
+  }
+
+  lookup_cache[hash] = itr - begin();
+
+  return itr;
 }
 
 DownloadMain*
 DownloadManager::find_main(const char* hash) {
-  iterator itr = std::find_if(begin(), end(), [hash](DownloadWrapper* wrapper) {
-    return *HashString::cast_from(hash) == wrapper->info()->hash();
-  });
+  auto itr = find(*HashString::cast_from(hash));
 
-  if (itr == end())
+  if (itr == end()) {
     return nullptr;
-  else
-    return (*itr)->main();
+  }
+
+  return (*itr)->main();
 }
 
 DownloadMain*
-DownloadManager::find_main_obfuscated(const char* hash) {
-  iterator itr = std::find_if(begin(), end(), [hash](DownloadWrapper* wrapper) {
-    return *HashString::cast_from(hash) == wrapper->info()->hash_obfuscated();
-  });
+DownloadManager::find_main_obfuscated(const char* obfuscated) {
+  auto hash_itr = obfuscated_to_hash.find(*HashString::cast_from(obfuscated));
 
-  if (itr == end())
+  if (hash_itr == obfuscated_to_hash.end()) {
     return nullptr;
-  else
-    return (*itr)->main();
+  }
+
+  auto itr = find(hash_itr->second);
+
+  if (itr == end()) {
+    return nullptr;
+  }
+
+  return (*itr)->main();
 }
 
 } // namespace torrent

--- a/test/torrent/test_hash_string.cc
+++ b/test/torrent/test_hash_string.cc
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+#include "torrent/hash_string.h"
+
+class HashStringTest : public ::testing::Test {};
+
+TEST_F(HashStringTest, test_basic) {
+  torrent::HashString hash;
+
+  std::unordered_map<torrent::HashString, int> m;
+  std::unordered_set<torrent::HashString>      s;
+
+  torrent::hash_string_from_hex_c_str(
+    "A94A8FE5CCB19BA61C4C0873D391E987982FBBD3", hash);
+
+  ASSERT_EQ(m.emplace(hash, 1).second, true);
+  ASSERT_EQ(m.find(hash)->second, 1);
+  ASSERT_EQ(m.emplace(hash, 1).second, false);
+
+  ASSERT_EQ(s.insert(hash).second, true);
+  ASSERT_NE(s.find(hash), s.end());
+  ASSERT_EQ(s.insert(hash).second, false);
+
+  torrent::hash_string_from_hex_c_str(
+    "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", hash);
+
+  ASSERT_EQ(m.find(hash)->second, 1);
+  ASSERT_NE(s.find(hash), s.end());
+
+  ASSERT_EQ(m.emplace(hash, 1).second, false);
+  ASSERT_EQ(s.insert(hash).second, false);
+}


### PR DESCRIPTION
```
download_manager: implement a lookup cache to speedup common cases

For most calls, the download list will be exactly the same as the
previous call. As such, implement a hashmap-based cache to speed
up this common case to O(1) lookup.
```