### PR TITLE
Respect "min interval" returned by the tracker for failed announces

### DIFF
--- a/include/test/helpers/tracker.h
+++ b/include/test/helpers/tracker.h
@@ -57,10 +57,14 @@ public:
   void set_success(uint32_t counter, uint32_t time_last) {
     m_success_counter   = counter;
     m_success_time_last = time_last;
+    m_normal_interval = default_normal_interval;
+    m_min_interval = default_min_interval;
   }
   void set_failed(uint32_t counter, uint32_t time_last) {
     m_failed_counter   = counter;
     m_failed_time_last = time_last;
+    m_normal_interval = 0;
+    m_min_interval = 0;
   }
   void set_latest_new_peers(uint32_t peers) {
     m_latest_new_peers = peers;

--- a/include/torrent/tracker.h
+++ b/include/torrent/tracker.h
@@ -36,6 +36,14 @@ public:
   static constexpr int max_flag_size   = 0x10;
   static constexpr int mask_base_flags = 0x10 - 1;
 
+  static constexpr int min_min_interval = 300;
+  static constexpr int default_min_interval = 600;
+  static constexpr int max_min_interval = 4 * 3600;
+
+  static constexpr int min_normal_interval = 600;
+  static constexpr int default_normal_interval = 1800;
+  static constexpr int max_normal_interval = 8 * 3600;
+
   virtual ~Tracker() = default;
 
   int flags() const {
@@ -175,10 +183,10 @@ protected:
   }
 
   void set_normal_interval(int v) {
-    m_normal_interval = std::min(std::max(600, v), 8 * 3600);
+    m_normal_interval = std::min(std::max(min_normal_interval, v), max_normal_interval);
   }
   void set_min_interval(int v) {
-    m_min_interval = std::min(std::max(300, v), 4 * 3600);
+    m_min_interval = std::min(std::max(min_min_interval, v), max_min_interval);
   }
 
   int m_flags;

--- a/include/tracker/tracker_http.h
+++ b/include/tracker/tracker_http.h
@@ -35,6 +35,7 @@ private:
   void receive_done();
   void receive_failed(const std::string& msg);
 
+  void process_failure(const Object& object);
   void process_success(const Object& object);
   void process_scrape(const Object& object);
 

--- a/src/torrent/tracker.cc
+++ b/src/torrent/tracker.cc
@@ -18,8 +18,8 @@ Tracker::Tracker(TrackerList* parent, std::string url, int flags)
   , m_url(std::move(url))
   ,
 
-  m_normal_interval(1800)
-  , m_min_interval(600)
+  m_normal_interval(0)
+  , m_min_interval(0)
   ,
 
   m_latest_event(EVENT_NONE)
@@ -75,7 +75,7 @@ Tracker::success_time_next() const {
   if (m_success_counter == 0)
     return 0;
 
-  return m_success_time_last + m_normal_interval;
+  return m_success_time_last + std::max(m_normal_interval, (uint32_t)default_min_interval);
 }
 
 uint32_t
@@ -83,8 +83,10 @@ Tracker::failed_time_next() const {
   if (m_failed_counter == 0)
     return 0;
 
-  return m_failed_time_last +
-         (5 << std::min(m_failed_counter - 1, (uint32_t)6));
+  if (m_min_interval > min_min_interval)
+    return m_failed_time_last + m_min_interval;
+
+  return m_failed_time_last + std::min(5 << std::min(m_failed_counter - 1, (uint32_t)6), min_min_interval-1);
 }
 
 std::string

--- a/src/torrent/tracker_controller.cc
+++ b/src/torrent/tracker_controller.cc
@@ -381,10 +381,11 @@ tracker_next_timeout_promiscuous(Tracker* tracker) {
 
   int32_t interval;
 
-  if (tracker->failed_counter())
-    interval = 5 << std::min<int>(tracker->failed_counter() - 1, 6);
-  else
+  if (tracker->failed_counter()) {
+    interval = tracker->failed_time_next() - tracker->failed_time_last();
+  } else {
     interval = tracker->normal_interval();
+  }
 
   int32_t min_interval = std::max(tracker->min_interval(), (uint32_t)300);
   int32_t use_interval = std::min(interval, min_interval);

--- a/src/tracker/tracker_udp.cc
+++ b/src/tracker/tracker_udp.cc
@@ -405,6 +405,7 @@ TrackerUdp::process_announce_output() {
     return false;
 
   set_normal_interval(m_readBuffer->read_32());
+  set_min_interval(default_min_interval);
 
   m_scrape_incomplete = m_readBuffer->read_32(); // leechers
   m_scrape_complete   = m_readBuffer->read_32(); // seeders

--- a/test/helpers/tracker.cc
+++ b/test/helpers/tracker.cc
@@ -31,10 +31,13 @@ TrackerTest::trigger_success(torrent::TrackerList::address_list* address_list,
   m_open           = !(m_flags & flag_close_on_done);
   return_new_peers = new_peers;
 
-  if (m_latest_event == EVENT_SCRAPE)
+  if (m_latest_event == EVENT_SCRAPE) {
     parent()->receive_scrape_success(this);
-  else
+  } else {
+    set_normal_interval(default_normal_interval);
+    set_min_interval(default_min_interval);
     parent()->receive_success(this, address_list);
+  }
 
   m_requesting_state = -1;
   return true;
@@ -49,10 +52,13 @@ TrackerTest::trigger_failure() {
   m_open           = !(m_flags & flag_close_on_done);
   return_new_peers = 0;
 
-  if (m_latest_event == EVENT_SCRAPE)
+  if (m_latest_event == EVENT_SCRAPE) {
     parent()->receive_scrape_failed(this, "failed");
-  else
+  } else {
+    set_normal_interval(0);
+    set_min_interval(0);
     parent()->receive_failed(this, "failed");
+  }
 
   m_requesting_state = -1;
   return true;

--- a/test/torrent/test_tracker_controller.cc
+++ b/test/torrent/test_tracker_controller.cc
@@ -107,8 +107,8 @@ TEST_F(tracker_controller_test, test_single_failure) {
   TEST_SINGLE_FAILURE_TIMEOUT(40);
   TEST_SINGLE_FAILURE_TIMEOUT(80);
   TEST_SINGLE_FAILURE_TIMEOUT(160);
-  TEST_SINGLE_FAILURE_TIMEOUT(320);
-  TEST_SINGLE_FAILURE_TIMEOUT(320);
+  TEST_SINGLE_FAILURE_TIMEOUT(299);
+  TEST_SINGLE_FAILURE_TIMEOUT(299);
 
   // TODO: Test with cachedTime not rounded to second.
 
@@ -302,7 +302,7 @@ TEST_F(tracker_controller_test, test_multiple_failure) {
 
   ASSERT_PRED3(test_goto_next_timeout,
                &tracker_controller,
-               tracker_0_0->normal_interval(),
+               tracker_1_0->normal_interval(),
                false);
   TEST_MULTI3_IS_BUSY("10000", "10000");
   ASSERT_TRUE(tracker_0_0->trigger_failure());

--- a/test/torrent/test_tracker_controller_requesting.cc
+++ b/test/torrent/test_tracker_controller_requesting.cc
@@ -31,6 +31,8 @@ do_test_hammering_basic(bool     success1,
 
   if (min_interval != 0)
     tracker_0_0->set_new_min_interval(min_interval);
+  else
+    tracker_0_0->set_new_min_interval(600);
 
   ASSERT_TRUE(tracker_0_0->is_busy());
   if (success1) {
@@ -124,6 +126,8 @@ do_test_hammering_multi3(bool     success1,
 
   if (min_interval != 0)
     tracker_0_0->set_new_min_interval(min_interval);
+  else
+    tracker_0_0->set_new_min_interval(600);
 
   TEST_MULTI3_IS_BUSY("10000", "10000");
   if (success1) {

--- a/test/torrent/test_tracker_timeout.cc
+++ b/test/torrent/test_tracker_timeout.cc
@@ -21,7 +21,7 @@ public:
 TEST_F(tracker_timeout_test, test_set_timeout) {
   TrackerTest tracker(nullptr, "");
 
-  ASSERT_EQ(tracker.normal_interval(), 1800);
+  ASSERT_EQ(tracker.normal_interval(), 0);
 
   tracker.set_new_normal_interval(100);
   ASSERT_EQ(tracker.normal_interval(), 600);
@@ -122,9 +122,9 @@ TEST_F(tracker_timeout_test, test_timeout_requesting) {
   tracker.set_failed(2, torrent::cachedTime.seconds());
   ASSERT_EQ(torrent::tracker_next_timeout(&tracker, flags), 10);
   tracker.set_failed(6 + 1, torrent::cachedTime.seconds());
-  ASSERT_EQ(torrent::tracker_next_timeout(&tracker, flags), 320);
+  ASSERT_EQ(torrent::tracker_next_timeout(&tracker, flags), 299);
   tracker.set_failed(7 + 1, torrent::cachedTime.seconds());
-  ASSERT_EQ(torrent::tracker_next_timeout(&tracker, flags), 320);
+  ASSERT_EQ(torrent::tracker_next_timeout(&tracker, flags), 299);
 
   // std::cout << "timeout:" << torrent::tracker_next_timeout(&tracker, flags)
   // << std::endl;


### PR DESCRIPTION
I understand that there's no desire for code which changes the network layer, this is merely a placeholder until the equivalent PR gets merged into vanilla.