### PR TITLE
Explicitly initialize m_errno to 0

### DIFF
--- a/include/torrent/utils/error_number.h
+++ b/include/torrent/utils/error_number.h
@@ -11,7 +11,8 @@ namespace utils {
 
 class error_number {
 public:
-  error_number() = default;
+  error_number()
+    : m_errno(static_cast<std::errc>(0)) {}
   error_number(std::errc e)
     : m_errno(e) {}
 


### PR DESCRIPTION
This doesn't necessarily happen implicitly when compiled with debug flags